### PR TITLE
Updates the asyncio syntax to python 3.10 standard.

### DIFF
--- a/smbus2_asyncio/__init__.py
+++ b/smbus2_asyncio/__init__.py
@@ -1,5 +1,6 @@
 """Smbus2 asyncio support."""
 import asyncio
+from functools import partial
 
 from smbus2 import SMBus
 
@@ -16,62 +17,38 @@ class SMBus2Asyncio:
             loop = asyncio.get_event_loop()
         self.loop = loop
         self.executor = executor
-        self.lock = asyncio.Lock(loop=loop)
+        self.lock = asyncio.Lock()
 
     def open_sync(self):
         """Open synchronous."""
         self.smbus = SMBus(self.bus)
 
-    @asyncio.coroutine
-    def open(self):
+    async def open(self):
         """Open async."""
         return self.loop.run_in_executor(self.executor, self.open_sync)
 
-    @asyncio.coroutine
-    def read_byte_data(self, i2c_addr, register):
+    async def read_byte_data(self, i2c_addr, register):
         """Read a single byte from a designated register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.read_byte_data, i2c_addr, register)
-        finally:
-          self.lock.release()
-        return result
+        async with self.lock:
+            return await self.loop.run_in_executor(
+                self.executor, partial(self.smbus.read_byte_data, i2c_addr, register)
+            )
 
-    @asyncio.coroutine
-    def read_i2c_block_data(self, i2c_addr, register, length):
+    async def read_i2c_block_data(self, i2c_addr, register, length):
         """Read a block of byte data from a given register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.read_i2c_block_data, i2c_addr, register, length)
-        finally:
-          self.lock.release()
-        return result
+        async with self.lock:
+            return await self.loop.run_in_executor(
+                self.executor,
+                partial(self.smbus.read_i2c_block_data, i2c_addr, register, length),
+            )
 
-    @asyncio.coroutine
-    def write_byte_data(self, i2c_addr, register, value):
+    async def write_byte_data(self, i2c_addr, register, value):
         """Write a byte to a given register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.write_byte_data, i2c_addr, register, value)
-        finally:
-          self.lock.release()
-
-        return result
-
-    @asyncio.coroutine
-    def write_i2c_block_data(self, i2c_addr, register, data):
-        """Write a block of byte data to a given register."""
-        assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.write_i2c_block_data, i2c_addr, register, data)
-        finally:
-          self.lock.release()
-        return result
+        async with self.lock:
+            return await self.loop.run_in_executor(
+                self.executor,
+                partial(self.smbus.write_byte_data, i2c_addr, register, value),
+            )


### PR DESCRIPTION
This update is heavily influenced by https://github.com/jabdoa2/smbus2_asyncio/pull/1 There were however some errors that needed to be handled.

Note: the use of `asyncio.get_event_loop()` is not recommended. When using this implementation be careful to make sure that a loop exists. We should probebly change this as soon as we figure out how it works. See: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop