### PR TITLE
Support for newer version of Python

### DIFF
--- a/smbus2_asyncio/__init__.py
+++ b/smbus2_asyncio/__init__.py
@@ -16,62 +16,54 @@ class SMBus2Asyncio:
             loop = asyncio.get_event_loop()
         self.loop = loop
         self.executor = executor
-        self.lock = asyncio.Lock(loop=loop)
+        self.lock = asyncio.Lock()
 
     def open_sync(self):
         """Open synchronous."""
         self.smbus = SMBus(self.bus)
 
-    @asyncio.coroutine
-    def open(self):
+    async def open(self):
         """Open async."""
-        return self.loop.run_in_executor(self.executor, self.open_sync)
+        return await self.loop.run_in_executor(self.executor, self.open_sync)
 
-    @asyncio.coroutine
-    def read_byte_data(self, i2c_addr, register):
+    async def read_byte_data(self, i2c_addr, register):
         """Read a single byte from a designated register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.read_byte_data, i2c_addr, register)
-        finally:
-          self.lock.release()
+        async with self.lock:
+            result = await self.loop.run_in_executor(
+                self.executor, self.smbus.read_byte_data, i2c_addr, register
+            )
         return result
 
-    @asyncio.coroutine
-    def read_i2c_block_data(self, i2c_addr, register, length):
+    async def read_i2c_block_data(self, i2c_addr, register, length):
         """Read a block of byte data from a given register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.read_i2c_block_data, i2c_addr, register, length)
-        finally:
-          self.lock.release()
+        async with self.lock:
+            result = await self.loop.run_in_executor(
+                self.executor,
+                self.smbus.read_i2c_block_data,
+                i2c_addr,
+                register,
+                length,
+            )
         return result
 
-    @asyncio.coroutine
-    def write_byte_data(self, i2c_addr, register, value):
+    async def write_byte_data(self, i2c_addr, register, value):
         """Write a byte to a given register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.write_byte_data, i2c_addr, register, value)
-        finally:
-          self.lock.release()
+        async with self.lock:
+            result = await self.loop.run_in_executor(
+                self.executor, self.smbus.write_byte_data, i2c_addr, register, value
+            )
 
         return result
 
-    @asyncio.coroutine
-    def write_i2c_block_data(self, i2c_addr, register, data):
+    async def write_i2c_block_data(self, i2c_addr, register, data):
         """Write a block of byte data to a given register."""
         assert self.smbus
-        yield from self.lock.acquire()
-        try:
-          result = yield from self.loop.run_in_executor(
-            self.executor, self.smbus.write_i2c_block_data, i2c_addr, register, data)
-        finally:
-          self.lock.release()
+        async with self.lock:
+            result = await self.loop.run_in_executor(
+                self.executor, self.smbus.write_i2c_block_data, i2c_addr, register, data
+            )
+
         return result

--- a/smbus2_asyncio/version.py
+++ b/smbus2_asyncio/version.py
@@ -1,2 +1,2 @@
 """Version string of smbus2_asyncio."""
-__version__ = "0.0.5"
+__version__ = "0.0.6"


### PR DESCRIPTION
Updated syntax '@asyncio.coroutine' to 'async def', 'yield from' to 'await'  and 'async with' for the lock. Tested on RPi5/Bookworm/Python 3.11.2 and it seems to work. Increased version number.

I am using this library to control i2c switches. When moving to a RPi5 with bookworm, it was generating sysntax error. This version works with admintedly  simple using only "open" and "write_byte_data".